### PR TITLE
Remove cobertura plugin as it appears abandoned, and does not work in JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,18 +123,7 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.7</version>
-				<configuration>
-					<formats>
-						<format>html</format>
-						<format>xml</format>
-					</formats>
-					<check />
-				</configuration>
-			</plugin>
+			
 
 			
 		</plugins>


### PR DESCRIPTION
Also we have codecov.io anyway.